### PR TITLE
Adds open class to link-tooltip for non-editing state

### DIFF
--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -40,9 +40,11 @@ class LinkTooltip extends Tooltip
     dom(@container.querySelector('.done')).on('click', _.bind(this.saveLink, this))
     dom(@container.querySelector('.remove')).on('click', =>
       this.removeLink(@range)
+      dom(@container).removeClass('open')
     )
     dom(@container.querySelector('.change')).on('click', =>
       this.setMode(@link.href, true)
+      dom(@container).removeClass('open')
     )
     this.initTextbox(@textbox, this.saveLink, this.hide)
     @quill.onModuleLoad('toolbar', (toolbar) =>
@@ -82,6 +84,7 @@ class LinkTooltip extends Tooltip
         @textbox.setSelectionRange(0, url.length)
       )
     else
+      dom(@container).addClass('open')
       @link.href = url
       url = @link.href # read back the url for further normalization
       text = if url.length > @options.maxLength then url.slice(0, @options.maxLength) + '...' else url

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -40,7 +40,6 @@ class LinkTooltip extends Tooltip
     dom(@container.querySelector('.done')).on('click', _.bind(this.saveLink, this))
     dom(@container.querySelector('.remove')).on('click', =>
       this.removeLink(@range)
-      dom(@container).removeClass('open')
     )
     dom(@container.querySelector('.change')).on('click', =>
       this.setMode(@link.href, true)

--- a/src/modules/tooltip.coffee
+++ b/src/modules/tooltip.coffee
@@ -37,8 +37,7 @@ class Tooltip
     @container.style.left = Tooltip.HIDE_MARGIN
     @quill.setSelection(@range) if @range
     @range = null
-    if dom(@container).hasClass('open')
-      dom(@container).removeClass('open')
+    dom(@container).removeClass('open')
 
   position: (reference) ->
     if reference?

--- a/src/modules/tooltip.coffee
+++ b/src/modules/tooltip.coffee
@@ -37,6 +37,8 @@ class Tooltip
     @container.style.left = Tooltip.HIDE_MARGIN
     @quill.setSelection(@range) if @range
     @range = null
+    if dom(@container).hasClass('open')
+      dom(@container).removeClass('open')
 
   position: (reference) ->
     if reference?


### PR DESCRIPTION
The link tooltip has three states:

1. Hidden / closed:
In this state, the tooltip is still present in the DOM, just shunted offscreen

2. Open & 'Editing':
In this state, the tooltip is being actively edited -- for the link tooltip, this means, e.g., the user is entering the href and can see the 'done' button (but not the 'change' or 'remove' buttons). This state has an associated 'editing' class.

3. Open & not 'editing':
In this state, the tooltip is _not_ being actively edited, but the tooltip is still visible on-screen. The user, in this case, sees 'change' and 'remove' buttons, but not the 'done' button. There is no associated class.

This PR adds an 'open' class to accompany the third state, as a hook for styling inside of, e.g., modals / sidebars, where the link tooltip might need to be manually positioned.