### PR TITLE
Fix paste

### DIFF
--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -9,7 +9,6 @@ Normalizer = require('./normalizer')
 
 class Document
   constructor: (@root, options = {}) ->
-    @normalizer = new Normalizer()
     @formats = {}
     @normalizer = new Normalizer()
     if _.isArray(options.formats)
@@ -115,7 +114,6 @@ class Document
 
   setHTML: (html) ->
     html = Normalizer.stripComments(html)
-    html = Normalizer.stripWhitespace(html)
     @root.innerHTML = html
     @lines = new LinkedList()
     this.rebuild()

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -56,8 +56,8 @@ class Normalizer
         node.style[style] = value
         node.removeAttribute(attribute)
     )
-    # Chrome turns <b> into style in some cases
-    if (node.style.fontWeight == 'bold' or node.style.fontWeight > 500)
+    # Turn inline fontWeight styling into <b> tags
+    if dom.BLOCK_TAGS[node.tagName] == null and (node.style.fontWeight == 'bold' or node.style.fontWeight > 500)
       node.style.fontWeight = ''
       dom(node).wrap(document.createElement('b'))
       node = node.parentNode


### PR DESCRIPTION
I noticed that when pasting the contents of https://chorus.voxmedia.com/editor/0c135e1d-5d75-4647-989a-7e369596ac60 between documents, that the headings would be lost, and certain spaces would go missing (words collapsed together).

I tracked this down to the following tweaks to the normalizer:

- Turn off `normalizeWhitespace` -- this does more harm than good.
- Only convert `fontWeight: bold` into a wrapper `<b>` tag for inline elements.