### PR TITLE
Reverse Merge

### DIFF
--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -73,7 +73,7 @@ class Document
     line.rebuild()
 
   reverseMergeLines: (sourceLine, targetLine) ->
-    if targetLine.length > 1
+    if sourceLine.length > 1
       dom(sourceLine.leaves.last.node).remove() if sourceLine.length == 1
       dom(targetLine.leaves.last.node).remove() if targetLine.length == 1
       # append target to source

--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -72,6 +72,17 @@ class Document
     this.removeLine(lineToMerge)
     line.rebuild()
 
+  reverseMergeLines: (sourceLine, targetLine) ->
+    if targetLine.length > 1
+      dom(sourceLine.leaves.last.node).remove() if sourceLine.length == 1
+      dom(targetLine.leaves.last.node).remove() if targetLine.length == 1
+      # append target to source
+      dom(targetLine.node).moveChildren(sourceLine.node)
+      # move source to target
+      dom(sourceLine.node).moveChildren(targetLine.node)
+    this.removeLine(sourceLine)
+    targetLine.rebuild()
+
   optimizeLines: ->
     # TODO optimize algorithm (track which lines get dirty and only Normalize.optimizeLine those)
     _.each(@lines.toArray(), (line, i) ->

--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -123,8 +123,15 @@ class Editor
         length -= deleteLength
         curLine = nextLine
         offset = 0
-      @doc.mergeLines(firstLine, firstLine.next) if mergeFirstLine and firstLine.next
+      this._mergeLines(firstLine) if mergeFirstLine and firstLine.next
     )
+
+  _mergeLines: (line) ->
+    reverseMerge = false
+    for key of line.formats
+      if @doc.formats[key] and @doc.formats[key].config.reverseMerge
+        reverseMerge = true
+    if reverseMerge then @doc.reverseMergeLines(line, line.next) else @doc.mergeLines(line, line.next)
 
   _formatAt: (index, length, name, value) ->
     @selection.shiftAfter(index, 0, =>


### PR DESCRIPTION
When merging two lines, let the `next` line's formatting override the previous if a config variable is present. Used internally at Vox for line-breaks.