### PR TITLE
Copy/paste using JSON

### DIFF
--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -3,14 +3,6 @@ Document = require('../core/document')
 _        = Quill.require('lodash')
 dom      = Quill.require('dom')
 Delta    = Quill.require('delta')
-cachedCanUpdateClipboard = null
-
-canUpdateClipboard = (dataTransfer) ->
-  if (cachedCanUpdateClipboard != null)
-    return cachedCanUpdateClipboard
-  dataTransfer.setData("text/html", "<hr>")
-  cachedCanUpdateClipboard = (dataTransfer.getData("text/html") == "<hr>")
-  return cachedCanUpdateClipboard
 
 class PasteManager
   @DEFAULTS:

--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -3,6 +3,14 @@ Document = require('../core/document')
 _        = Quill.require('lodash')
 dom      = Quill.require('dom')
 Delta    = Quill.require('delta')
+cachedCanUpdateClipboard = null
+
+canUpdateClipboard = (dataTransfer) ->
+  if (cachedCanUpdateClipboard != null)
+    return cachedCanUpdateClipboard
+  dataTransfer.setData("text/html", "<hr>")
+  cachedCanUpdateClipboard = (dataTransfer.getData("text/html") == "<hr>")
+  return cachedCanUpdateClipboard
 
 class PasteManager
   @DEFAULTS:
@@ -12,6 +20,8 @@ class PasteManager
     @container = @quill.addContainer('ql-paste-manager')
     @container.setAttribute('contenteditable', true)
     @container.setAttribute('tabindex', '-1')
+    dom(@quill.root).on('cut', _.bind(this._cut, this))
+    dom(@quill.root).on('copy', _.bind(this._copy, this))
     dom(@quill.root).on('paste', _.bind(this._paste, this))
     @options = _.defaults(options, PasteManager.DEFAULTS)
     @options.onConvert ?= this._onConvert;
@@ -29,10 +39,48 @@ class PasteManager
     # Need to remove trailing newline so paste is inline, losing format is expected and observed in Word
     return delta.compose(new Delta().retain(lengthAdded - 1).delete(1))
 
-  _paste: ->
-    oldDocLength = @quill.getLength()
+  _cut: (event) ->
+    this._copy(event)
     range = @quill.getSelection()
     return unless range?
+    { start, end } = range
+    # if the surrounding characters are both spaces,
+    # kill the preceding space to prevent leaving double-spaces
+    before = @quill.getText(Math.max(start - 1, 0), start)
+    after = @quill.getText(end, Math.min(end + 1, @quill.getLength()))
+    if ' ' == before == after
+      start = start - 1
+    @quill.deleteText(start, end, 'user')
+
+  _copy: (event) ->
+    range = @quill.getSelection()
+    if range
+      delta = @quill.getContents(range)
+      event.clipboardData.setData('application/rich-text+json', JSON.stringify(delta))
+
+      text = @quill.getText(range)
+      event.clipboardData.setData('text/plain', text)
+
+    nativeRange = @quill.editor.selection._getNativeRange()
+    if nativeRange
+      div = document.createElement('div')
+      div.appendChild(nativeRange.cloneContents())
+      event.clipboardData.setData('text/html', div.innerHTML)
+
+    event.preventDefault()
+
+  _paste: (event) ->
+    range = @quill.getSelection()
+    return unless range?
+
+    if event.clipboardData?.types.indexOf('application/rich-text+json') > -1
+      delta = JSON.parse event.clipboardData.getData('application/rich-text+json')
+      delta = new Delta().retain(range.start).delete(range.end - range.start).concat(delta)
+      @quill.updateContents(delta, 'user')
+      event.preventDefault()
+      return
+
+    oldDocLength = @quill.getLength()
     @container.focus()
     _.defer( =>
       delta = @options.onConvert(@container)

--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -56,7 +56,7 @@ class PasteManager
     range = @quill.getSelection()
     if range
       delta = @quill.getContents(range)
-      event.clipboardData.setData('application/rich-text+json', JSON.stringify(delta))
+      event.clipboardData.setData('application/json', JSON.stringify(delta))
 
       text = @quill.getText(range)
       event.clipboardData.setData('text/plain', text)
@@ -73,12 +73,15 @@ class PasteManager
     range = @quill.getSelection()
     return unless range?
 
-    if event.clipboardData?.types.indexOf('application/rich-text+json') > -1
-      delta = JSON.parse event.clipboardData.getData('application/rich-text+json')
-      delta = new Delta().retain(range.start).delete(range.end - range.start).concat(delta)
-      @quill.updateContents(delta, 'user')
-      event.preventDefault()
-      return
+    if _.includes(event.clipboardData?.types, 'application/json')
+      try
+        removal = new Delta().retain(range.start).delete(range.end - range.start)
+        insertion = new Delta(JSON.parse(event.clipboardData.getData('application/json')))
+        @quill.updateContents(removal.concat(insertion), 'user')
+        event.preventDefault()
+        return
+      finally
+        # fall back to native behavior
 
     oldDocLength = @quill.getLength()
     @container.focus()


### PR DESCRIPTION
Put JSON and plaintext data directly onto the clipboard using the `clipboardData` HTML5 API. This will allow one to paste rich-text data exactly as it was captured, to avoid sending it through the rigorous cleanup we apply to incoming html (such as stripping empty lines).

Seems to work for copy/pasting in the same browser, but the custom clipboard data seems to be lost when copying in one browser and pasting in another.