### PR TITLE
Line affinity handling for `enter` events

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -70,8 +70,8 @@ class Keyboard
 
       removeInheritedFormats = {}
       removeNonInheritedFormats = {}
-      removeFromNewLine = {}
-      removeFromOriginalLine = {}
+      removeFromRightLine = {}
+      removeFromLeftLine = {}
       for name, value of line.formats
         format = @quill.editor.doc.formats[name]
         if format and format.isType('line')
@@ -79,16 +79,16 @@ class Keyboard
             removeInheritedFormats[name] = false
           if !format.config.inherit
             removeNonInheritedFormats[name] = false
-          if format.config.lineAffinity == 'before'
-            removeFromOriginalLine[name] = null
-          if format.config.lineAffinity == 'after'
-            removeFromNewLine[name] = null
+          if format.config.splitAffinity == 'left'
+            removeFromLeftLine[name] = null
+          if format.config.splitAffinity == 'right'
+            removeFromRightLine[name] = null
 
       # if on an empty line, remove the inheritable formats
       if range.isCollapsed() and line.length == 1 and Object.keys(removeInheritedFormats).length > 0
         delta.retain(1, removeInheritedFormats)
       else
-        delta.insert('\n', Object.assign({}, line.formats, removeFromNewLine)).delete(range.end - range.start)
+        delta.insert('\n', Object.assign({}, line.formats, removeFromRightLine)).delete(range.end - range.start)
 
       # if creating a new empty line (was at the end of the old line),
       # remove line formats from the new line that should not be inherited
@@ -96,7 +96,7 @@ class Keyboard
         delta.retain(1, removeNonInheritedFormats)
       else
         delta.retain(leaf.length - offset)
-        delta.retain(1, Object.assign({}, line.formats, removeFromOriginalLine))
+        delta.retain(1, Object.assign({}, line.formats, removeFromLeftLine))
 
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -67,29 +67,36 @@ class Keyboard
       [line, offset] = @quill.editor.doc.findLineAt(range.start)
       [leaf, offset] = line.findLeafAt(offset)
       delta = new Delta().retain(range.start)
-      removeInheritedFormats = _.reduce(line.formats, (formats, value, name) =>
+
+      removeInheritedFormats = {}
+      removeNonInheritedFormats = {}
+      removeFromNewLine = {}
+      removeFromOriginalLine = {}
+      for name, value of line.formats
         format = @quill.editor.doc.formats[name]
-        if format and format.isType('line') and format.config.inherit
-          formats[name] = false
-        return formats
-      , {})
-      removeNonInheritedFormats = _.reduce(line.formats, (formats, value, name) =>
-        format = @quill.editor.doc.formats[name]
-        if format and format.isType('line') and !format.config.inherit
-          formats[name] = false
-        return formats
-      , {})
+        if format and format.isType('line')
+          if format.config.inherit
+            removeInheritedFormats[name] = false
+          if !format.config.inherit
+            removeNonInheritedFormats[name] = false
+          if format.config.lineAffinity == 'before'
+            removeFromOriginalLine[name] = null
+          if format.config.lineAffinity == 'after'
+            removeFromNewLine[name] = null
 
       # if on an empty line, remove the inheritable formats
       if range.isCollapsed() and line.length == 1 and Object.keys(removeInheritedFormats).length > 0
         delta.retain(1, removeInheritedFormats)
       else
-        delta.insert('\n', line.formats).delete(range.end - range.start)
+        delta.insert('\n', Object.assign({}, line.formats, removeFromNewLine)).delete(range.end - range.start)
 
       # if creating a new empty line (was at the end of the old line),
       # remove line formats from the new line that should not be inherited
       if !leaf.next and offset == leaf.length
         delta.retain(1, removeNonInheritedFormats)
+      else
+        delta.retain(leaf.length - offset)
+        delta.retain(1, Object.assign({}, line.formats, removeFromOriginalLine))
 
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -80,15 +80,15 @@ class Keyboard
           if !format.config.inherit
             removeNonInheritedFormats[name] = false
           if format.config.splitAffinity == 'left'
-            removeFromLeftLine[name] = null
-          if format.config.splitAffinity == 'right'
             removeFromRightLine[name] = null
+          if format.config.splitAffinity == 'right'
+            removeFromLeftLine[name] = null
 
       # if on an empty line, remove the inheritable formats
       if range.isCollapsed() and line.length == 1 and Object.keys(removeInheritedFormats).length > 0
         delta.retain(1, removeInheritedFormats)
       else
-        delta.insert('\n', Object.assign({}, line.formats, removeFromRightLine)).delete(range.end - range.start)
+        delta.insert('\n', Object.assign({}, line.formats, removeFromLeftLine)).delete(range.end - range.start)
 
       # if creating a new empty line (was at the end of the old line),
       # remove line formats from the new line that should not be inherited
@@ -96,7 +96,7 @@ class Keyboard
         delta.retain(1, removeNonInheritedFormats)
       else
         delta.retain(leaf.length - offset)
-        delta.retain(1, Object.assign({}, line.formats, removeFromLeftLine))
+        delta.retain(1, Object.assign({}, line.formats, removeFromRightLine))
 
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>


### PR DESCRIPTION
The `splitAffinity` attribute will be used for line formats that apply to paragraphs/chunks of text. When a text chunk is broken up via an `enter` keypress, splitAffinity directs us to keep the format applied to the proper chunk of text.

- If `splitAffinity: 'left'`, the first block should retain the format. The format will be applied to the new line and removed from the original line
- If `splitAffinity: 'right`, the second block should retain the format. The format will not be applied to the new line.
- If no splitAffinity config exists, both the new and original lines will keep the format, as will both chunks of text