### PR TITLE
Tooltip Bugfix

### DIFF
--- a/src/modules/tooltip.coffee
+++ b/src/modules/tooltip.coffee
@@ -15,7 +15,7 @@ class Tooltip
     @container.innerHTML = @options.template
     this.hide()
     @quill.on(@quill.constructor.events.TEXT_CHANGE, (delta, source) =>
-      if @container.style.left != Tooltip.HIDE_MARGIN
+      if source == 'user' and @container.style.left != Tooltip.HIDE_MARGIN
         @range = null
         this.hide()
     )


### PR DESCRIPTION
Only close an active tooltip on a `text-change` event sourced from the current user.