### PR TITLE
Fix editor.applyDelta() to treat trailing newlines better, with test

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -40,10 +40,20 @@ class Editor
       delta = localDelta.transform(delta, true)
     if delta.ops.length > 0
       delta = this._trackDelta( =>
+        consumeNextNewline = false
         index = 0
         _.each(delta.ops, (op) =>
           if _.isString(op.insert)
-            this._insertAt(index, op.insert, op.attributes)
+            text = op.insert
+            if _.last(op.insert) == '\n' and consumeNextNewline
+              consumeNextNewline = false
+              text = text.slice(0, -1)
+            if index >= @length && _.last(op.insert) != '\n'
+              consumeNextNewline = true
+            this._insertText(index, text)
+            _.each(op.attributes, (value, name) =>
+              this._formatAt(index, op.insert.length, name, value)
+            )
             index += op.insert.length;
           else if _.isNumber(op.insert)
             this._insertEmbed(index, op.attributes)
@@ -152,7 +162,7 @@ class Editor
       line.insertEmbed(offset, attributes)
     )
 
-  _insertAt: (index, text, formatting = {}) ->
+  _insertText: (index, text) ->
     @selection.shiftAfter(index, text.length, =>
       text = text.replace(/\r\n?/g, '\n')
       lineTexts = text.split('\n')
@@ -162,16 +172,12 @@ class Editor
           if i < lineTexts.length - 1 or lineText.length > 0
             line = @doc.appendLine(document.createElement(dom.DEFAULT_BLOCK_TAG))
             offset = 0
-            line.insertText(offset, lineText, formatting)
-            line.format(formatting)
+            line.insertText(offset, lineText)
             nextLine = null
         else
-          line.insertText(offset, lineText, formatting)
+          line.insertText(offset, lineText)
           if i < lineTexts.length - 1       # Are there more lines to insert?
             nextLine = @doc.splitLine(line, offset + lineText.length)
-            _.each(_.defaults({}, formatting, line.formats), (value, format) ->
-              line.format(format, formatting[format])
-            )
             offset = 0
         line = nextLine
       )

--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -42,24 +42,28 @@ class Editor
       delta = this._trackDelta( =>
         consumeNextNewline = false
         index = 0
+        length = @length
         _.each(delta.ops, (op) =>
           if _.isString(op.insert)
             text = op.insert
             if _.last(op.insert) == '\n' and consumeNextNewline
               consumeNextNewline = false
               text = text.slice(0, -1)
-            if index >= delta.length() && _.last(op.insert) != '\n'
+            if index >= length && _.last(op.insert) != '\n'
               consumeNextNewline = true
             this._insertText(index, text)
             _.each(op.attributes, (value, name) =>
               this._formatAt(index, op.insert.length, name, value)
             )
-            index += op.insert.length;
+            index += op.insert.length
+            length += op.insert.length
           else if _.isNumber(op.insert)
             this._insertEmbed(index, op.attributes)
-            index += 1;
+            index += 1
+            length += 1
           else if _.isNumber(op.delete)
             this._deleteAt(index, op.delete)
+            length -= op.delete
           else if _.isNumber(op.retain)
             _.each(op.attributes, (value, name) =>
               this._formatAt(index, op.retain, name, value)

--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -48,7 +48,7 @@ class Editor
             if _.last(op.insert) == '\n' and consumeNextNewline
               consumeNextNewline = false
               text = text.slice(0, -1)
-            if index >= @length && _.last(op.insert) != '\n'
+            if index >= delta.length() && _.last(op.insert) != '\n'
               consumeNextNewline = true
             this._insertText(index, text)
             _.each(op.attributes, (value, name) =>

--- a/test/unit/core/editor.coffee
+++ b/test/unit/core/editor.coffee
@@ -207,7 +207,7 @@ describe('Editor', ->
     )
   )
 
-  describe('insertEmbed()', ->
+  describe('_insertEmbed()', ->
     it('insert image', ->
       @editor.doc.setHTML('<div>A</div>')
       @editor._insertEmbed(1, { image: "http://quilljs.com/images/cloud.png" })
@@ -257,6 +257,11 @@ describe('Editor', ->
           <div>012356|</div>
           <div>|78</div>
           <div style="text-align: right;">abcd</div>'
+      'trailing newline':
+        initial: '<div>0123</div>'
+        delta: new Quill.Delta().retain(5).insert('|').insert('\n', { align: 'right' })
+        expected: '
+          <div>0123</div><div style="text-align: right;">|</div>'
 
     _.each(tests, (test, name) ->
       it(name, ->

--- a/test/unit/core/editor.coffee
+++ b/test/unit/core/editor.coffee
@@ -259,9 +259,20 @@ describe('Editor', ->
           <div style="text-align: right;">abcd</div>'
       'trailing newline':
         initial: '<div>0123</div>'
+        delta: new Quill.Delta().retain(5).insert('|\n')
+        expected: '<div>0123</div><div>|</div>'
+      'formatted trailing newline':
+        initial: '<div>0123</div>'
         delta: new Quill.Delta().retain(5).insert('|').insert('\n', { align: 'right' })
-        expected: '
-          <div>0123</div><div style="text-align: right;">|</div>'
+        expected: '<div>0123</div><div style="text-align: right;">|</div>'
+      'delete with trailing newline':
+        initial: '<div>0123</div>'
+        delta: new Quill.Delta().delete(1).retain(4).insert('|').insert('\n', { align: 'right' })
+        expected: '<div>123</div><div style="text-align: right;">|</div>'
+      'multiple trailing newlines':
+        initial: '<div>0123</div>'
+        delta: new Quill.Delta().retain(5).insert('45').insert('\n').insert('67').insert('\n')
+        expected: '<div>0123</div><div>45</div><div>67</div>'
 
     _.each(tests, (test, name) ->
       it(name, ->


### PR DESCRIPTION
This backports a fix from the mainline project for quilljs/quill#637. I've adapted that fix for a minimal diff to our fork, and added a test to verify it's working as intended. (The test passes though the suite does not, to be fixed by a different PR).

The fix works by looking at each applied `insert` op, to see if the trailing newline should be skipped due to that line having been implicitly created by an earlier op.