### PR TITLE
Bugfix: Allow copying contents when Quill is disabled

### DIFF
--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -6,6 +6,9 @@ Range      = require('../lib/range')
 
 
 class Selection
+  @DEFAULTS:
+    rangeOpts: { ignoreFocus: false, overrideFocus: false }
+
   constructor: (@doc, @emitter) ->
     @focus = false
     @range = new Range(0, 0)
@@ -15,8 +18,9 @@ class Selection
   checkFocus: ->
     return document.activeElement == @doc.root
 
-  getRange: (ignoreFocus = false) ->
-    if this.checkFocus()
+  getRange: (opts = {}) ->
+    { ignoreFocus, overrideFocus } = _.defaults(opts, Selection.DEFAULTS.rangeOpts)
+    if this.checkFocus() || overrideFocus
       nativeRange = this._getNativeRange()
       return null unless nativeRange?
       start = this._positionToIndex(nativeRange.startContainer, nativeRange.startOffset)
@@ -77,7 +81,7 @@ class Selection
 
   update: (source) ->
     focus = this.checkFocus()
-    range = this.getRange(true)
+    range = this.getRange({ ignoreFocus: true })
     emit = source != 'silent' and (!Range.compare(range, @range) or focus != @focus)
     toEmit = if focus then range else null
     # If range changes to null, require two update cycles to update and emit

--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -45,7 +45,7 @@ class PasteManager
     @quill.deleteText(start, end, 'user')
 
   _copy: (event) ->
-    range = @quill.getSelection()
+    range = @quill.getSelection({ overrideFocus: true })
     if range
       delta = @quill.getContents(range)
       event.clipboardData.setData('application/json', JSON.stringify(delta))

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -152,7 +152,7 @@ class Quill extends EventEmitter2
   getModule: (name) ->
     return @modules[name]
 
-  getSelection: (opts) ->
+  getSelection: (opts = {}) ->
     @editor.checkUpdate()   # Make sure we access getRange with editor in consistent state
     return @editor.selection.getRange(opts)
 

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -152,9 +152,9 @@ class Quill extends EventEmitter2
   getModule: (name) ->
     return @modules[name]
 
-  getSelection: ->
+  getSelection: (opts) ->
     @editor.checkUpdate()   # Make sure we access getRange with editor in consistent state
-    return @editor.selection.getRange()
+    return @editor.selection.getRange(opts)
 
   getText: (start = 0, end = null) ->
     return _.map(this.getContents(start, end).ops, (op) ->

--- a/test/unit/core/selection.coffee
+++ b/test/unit/core/selection.coffee
@@ -300,7 +300,7 @@ describe('Selection', ->
       _.defer( =>
         expect(@quill.editor.selection.checkFocus()).not.toBeTruthy()
         expect(@quill.getSelection()).not.toBeTruthy()
-        savedRange = @quill.editor.selection.getRange(true)
+        savedRange = @quill.editor.selection.getRange({ ignoreFocus: true })
         expect(savedRange).toBeTruthy()
         expect(savedRange.start).toEqual(2)
         expect(savedRange.end).toEqual(3)


### PR DESCRIPTION
Fixes https://github.com/voxmedia/anthem/issues/3534

Our custom copy logic relies on a quill `range` to retrieve the plaintext and JSON data to be stored in the clipboard. In turn, `Selection.getRange`, the method that ultimately provides this range, returns `null` when quill is disabled. This is because users cannot focus on the quill instance root when disabled.

To resolve this issue, I've added a new option to be passed down to the `getRange` method so that we always try to retrieve a selection range, even if the user isn't technically focused on `@doc.root`.

**Alternate proposal**
In `getRange`, we could remove all reference to `checkFocus`. Instead, the first block of logic, which converts a native range to a quill range, would only run if `Selection._getNativeRange` returned data. The native range getter function ensures a range is only returned if it's for a selection within the quill container. This reality seems to render the `checkFocus` call moot. Or, maybe it's still worthwhile?
