### PR TITLE
Define attribute/style/class formats in spans, not in other tags

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -108,7 +108,7 @@ class Format
     if _.isString(@config.style) or _.isString(@config.attribute) or _.isString(@config.class)
       if _.isString(@config.class)
         node = this.remove(node)
-      if !this.isType(Format.types.LINE) and node.tagName != dom.DEFAULT_INLINE_TAG
+      if !this.isType(Format.types.LINE) and !this.isType(Format.types.EMBED) and node.tagName != dom.DEFAULT_INLINE_TAG
         inline = document.createElement(dom.DEFAULT_INLINE_TAG)
         dom(node).wrap(inline)
         node = inline

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -108,7 +108,7 @@ class Format
     if _.isString(@config.style) or _.isString(@config.attribute) or _.isString(@config.class)
       if _.isString(@config.class)
         node = this.remove(node)
-      if dom(node).isTextNode()
+      if !this.isType(Format.types.LINE) and node.tagName != dom.DEFAULT_INLINE_TAG
         inline = document.createElement(dom.DEFAULT_INLINE_TAG)
         dom(node).wrap(inline)
         node = inline

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -165,26 +165,9 @@ class Normalizer
           nodes.push(node.firstChild)
           dom(node.previousSibling).merge(node)
 
-  # If a <span>, move attributes as high in the tree as possible and unwrap,
-  # otherwise, alphabetize nesting order of tag names (prefer <a> to be outer-most)
+  # Alphabetize nesting order of tag names (prefer <a> to be outer-most)
   @optimizeNesting: (node, root) ->
-    if node.tagName == dom.DEFAULT_INLINE_TAG
-      # find all parents with only one child, up to the root
-      parents = []
-      next = node.parentNode
-      while next != root and next.firstChild == next.lastChild
-        parents.push(next)
-        next = next.parentNode
-      # choose the parent with the earliest tag name, alphabetically
-      target = _.sortBy(parents, 'tagName')[0]
-      # Move attributes to the target, and unwrap
-      for name, value of dom(node).attributes()
-        if name == 'class' && target.hasAttribute('class')
-          value = [target.getAttribute('class'), value].join(' ')
-        target.setAttribute(name, value)
-      dom(node).unwrap()
-      return target
-    else if node.parentNode.tagName > node.tagName
+    if node.parentNode.tagName > node.tagName
       # Order tag nesting alphabetically (parent->child : A->Z)
       dom(node).moveChildren(node.parentNode)
       dom(node.parentNode).wrap(node)

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -159,6 +159,7 @@ class Normalizer
         if node.nextSibling?
           nodes.push(node.nextSibling)
 
+      # If an inline tag has no attributes after optimization, unwrap it
       if node.tagName == dom.DEFAULT_INLINE_TAG and !node.hasAttributes()
         dom(node).unwrap()
 
@@ -168,7 +169,7 @@ class Normalizer
           nodes.push(node.firstChild)
           dom(node.previousSibling).merge(node)
 
-  # If a <span>, merge with the parent span if possible,
+  # If the node is an inline tag, merge with the parent inline tag if possible,
   # otherwise, alphabetize nesting order of tag names (prefer <a> to be outer-most)
   @optimizeNesting: (node, root) ->
     if node.tagName == dom.DEFAULT_INLINE_TAG and node.parentNode.tagName == dom.DEFAULT_INLINE_TAG

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -169,18 +169,18 @@ class Normalizer
           nodes.push(node.firstChild)
           dom(node.previousSibling).merge(node)
 
-  # If the node is an inline tag, merge with the parent inline tag if possible,
+  # Merge the node with its parent if their tags are the same,
   # otherwise, alphabetize nesting order of tag names (prefer <a> to be outer-most)
   @optimizeNesting: (node, root) ->
-    if node.tagName == dom.DEFAULT_INLINE_TAG and node.parentNode.tagName == dom.DEFAULT_INLINE_TAG
-      target = node.parentNode
-      # Move attributes to the target, and unwrap
+    if node.tagName == node.parentNode.tagName
+      parent = node.parentNode
+      # Move attributes to the parent, and unwrap
       for name, value of dom(node).attributes()
-        if name == 'class' && target.hasAttribute('class')
-          value = [target.getAttribute('class'), value].join(' ')
-        target.setAttribute(name, value)
+        if name == 'class' && parent.hasAttribute('class')
+          value = [parent.getAttribute('class'), value].join(' ')
+        parent.setAttribute(name, value)
       dom(node).unwrap()
-      return target
+      return parent
     else if node.parentNode.tagName > node.tagName
       # Order tag nesting alphabetically (parent->child : A->Z)
       dom(node).moveChildren(node.parentNode)

--- a/test/unit/core/line.coffee
+++ b/test/unit/core/line.coffee
@@ -284,8 +284,8 @@ describe('Line', ->
         expected: "<b>01</b><s>34</s>"
         args: [2, 1, 'image', false]
       'change format':
-        initial: '<b style="color: red;">012</b>'
-        expected: '<b style="color: red;">0</b><b style="color: blue;">1</b><b style="color: red;">2</b>'
+        initial: '<b><span style="color: red;">012</span></b>'
+        expected: '<b><span style="color: red;">0</span><span style="color: blue;">1</span><span style="color: red;">2</span></b>'
         args: [1, 1, 'color', 'blue']
 
     _.each(tests, (test, name) ->

--- a/test/unit/core/normalizer.coffee
+++ b/test/unit/core/normalizer.coffee
@@ -130,7 +130,7 @@ describe('Normalizer', ->
         expected: '<em><strong>A</strong>B</em>'
       'unwrap span':
         initial:  '<strong><em><span class="author-1">A</span></em></strong>'
-        expected: '<em class="author-1"><strong>A</strong></em>'
+        expected: '<em><strong><span class="author-1">A</span></strong></em>'
 
 
     _.each(tests, (test, name) ->


### PR DESCRIPTION
In #15, we made changes to how the normalizer optimizes nesting. Now we're taking that a step further: `span` tags are now the way that style/class/attribute values are stored and nested, and all other tags are organized alphabetically around that.

This is in order to correct situations with nested users in links as seen in https://github.com/voxmedia/anthem/issues/495.