### PR TITLE
Fix links, attempt number 48

### DIFF
--- a/config/grunt/server.coffee
+++ b/config/grunt/server.coffee
@@ -16,6 +16,7 @@ browserifyOps =
   fullPaths: true
   packageCache: {}
   standalone: 'Quill'
+  debug: true
 
 
 bundle = (watcher) ->

--- a/examples/advanced.jade
+++ b/examples/advanced.jade
@@ -5,6 +5,8 @@ html
   head
     title Quill Pretty Editor Demo
     meta(charset='utf-8')
+    link(rel='stylesheet', href='styles/style.css')
+    link(rel='stylesheet', href='styles/advanced.css')
 
   body
     #content-container

--- a/examples/index.jade
+++ b/examples/index.jade
@@ -3,6 +3,7 @@ html
   head
     title Quill Editor Demo
     meta(charset='utf-8')
+    link(rel='stylesheet', href='styles/style.css')
 
   body
     #content-container
@@ -57,6 +58,7 @@ html
     script(type='text/javascript').
       var editor = new Quill('#editor-container', {
         modules: {
+          'authorship': { authorId: '1' },
           'toolbar': { container: '#formatting-container' },
           'link-tooltip': true,
           'image-tooltip': true

--- a/examples/styles/advanced.styl
+++ b/examples/styles/advanced.styl
@@ -19,6 +19,5 @@
 
 .basic-wrapper .toolbar-container
   padding: 8px 14px
-  .ql-active, button:hover
-    color: green
+  .ql-active
     font-weight: bold

--- a/examples/styles/style.styl
+++ b/examples/styles/style.styl
@@ -11,8 +11,7 @@ body
   background-color: #f5f5f5
   border-bottom: 1px solid #ccc
   padding: 5px 12px
-  .ql-active, button:hover
-    color: green
+  .ql-active
     font-weight: bold
 
 #editor-container
@@ -21,3 +20,42 @@ body
 #editor-wrapper
   border: 1px solid #aaa
   box-shadow: 0 0 2px 2px #ddd
+
+.ql-container
+  position: relative
+
+.ql-editor
+  white-space: pre-wrap
+  height: 100%
+  padding: 10px
+
+.ql-tooltip, .ql-multi-cursor, .ql-paste-manager
+  position: absolute
+  top: 0px
+  z-index: 1000
+
+.ql-multi-cursor .cursor
+  position: absolute
+
+.ql-multi-cursor .cursor-caret
+  position: absolute
+  width: 3px
+  height: 100%
+
+.ql-multi-cursor .cursor-flag
+
+.ql-multi-cursor .cursor.hidden:not(:hover) .cursor-flag
+  display: none
+
+.ql-link-tooltip
+  padding: 8px 10px
+  background: #fff
+  border: 1px solid #aaa
+
+.ql-link-tooltip:not(.editing)
+  .input, .done
+    display: none
+
+.ql-link-tooltip.editing
+  .url, .change, .remove
+    display: none

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -189,9 +189,8 @@ class Normalizer
         parent = parent.parentNode
       dom(node).unwrap()
       dom(parent).wrap(node)
-      return node
-    else
-      return node
+
+    return node
 
   # Make sure descendants are all inline elements
   @pullBlocks: (lineNode) ->

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -151,9 +151,8 @@ class Normalizer
         dom(node).unwrap()
         continue
 
-      # If node is an only child, and parent is not the lineNode,
-      # normalize nesting order
-      if node.parentNode != lineNode and !node.previousSibling? and !node.nextSibling?
+      # If parent is not the lineNode, normalize nesting order
+      if node.parentNode != lineNode
         node = @optimizeNesting(node, lineNode)
         # check next sibling again in case it is similar enough to merge
         if node.nextSibling?
@@ -180,11 +179,16 @@ class Normalizer
           value = [parent.getAttribute('class'), value].join(' ')
         parent.setAttribute(name, value)
       dom(node).unwrap()
-      return parent
-    else if node.parentNode.tagName > node.tagName
+      node = parent
+
+    if node.parentNode != root and node.parentNode.tagName > node.tagName
       # Order tag nesting alphabetically (parent->child : A->Z)
-      dom(node).moveChildren(node.parentNode)
-      dom(node.parentNode).wrap(node)
+      dom(node).isolate(root)
+      parent = node.parentNode
+      while parent.parentNode != root and parent.tagName > node.tagName
+        parent = parent.parentNode
+      dom(node).unwrap()
+      dom(parent).wrap(node)
       return node
     else
       return node

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -72,6 +72,7 @@ class Toolbar
       until dom(target).hasClass("ql-#{name}") or target == @container
         target = target.parentNode
       return unless target? and target != @container
+      return if target.tagName == 'SELECT' and event.type == 'click'
 
       value =
         if target.tagName == 'SELECT'

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -55,6 +55,7 @@ class Quill extends EventEmitter2
     moduleOptions = _.defaults(options.modules or {}, Quill.DEFAULTS.modules)
     html = @container.innerHTML
     @container.innerHTML = ''
+    dom(@container).addClass('ql-container')
     @options = _.defaults(options, Quill.DEFAULTS)
     @options.modules = moduleOptions
     @options.id = @id = "ql-editor-#{Quill.editors.length + 1}"

--- a/test/unit/core/normalizer.coffee
+++ b/test/unit/core/normalizer.coffee
@@ -118,7 +118,7 @@ describe('Normalizer', ->
         expected: '<img src="http://quilljs.com/images/cloud.png"><img src="http://quilljs.com/images/cloud.png">'
       'wrap orphaned text node':
         initial:  '<s><b>0</b></s><s><span>1</span></s>'
-        expected: '<s><b>0</b>1</s>'
+        expected: '<b><s>0</s></b><s>1</s>'
       'merge text nodes':
         initial:  'A <b></b> B.'
         expected:  'A  B.'
@@ -128,9 +128,15 @@ describe('Normalizer', ->
       'reorder nodes plus merge':
         initial:  '<strong><em>A</em></strong><em>B</em>'
         expected: '<em><strong>A</strong>B</em>'
-      'unwrap span':
-        initial:  '<strong><em><span class="author-1">A</span></em></strong>'
-        expected: '<em><strong><span class="author-1">A</span></strong></em>'
+      'reorder nodes with siblings':
+        initial: '<strong>A<em>B</em>C</strong>'
+        expected: '<strong>A</strong><em><strong>B</strong></em><strong>C</strong>'
+      'reoder and merge nodes':
+        initial: '<s>A<b>B</b><i>C</i></s><i>D</d>'
+        expected: '<s>A</s><b><s>B</s></b><i><s>C</s>D</i>'
+      'dont reorder void tags':
+        initial: '<strong><img /></strong>'
+        expected: '<strong><img /></strong>'
 
 
     _.each(tests, (test, name) ->


### PR DESCRIPTION
This broadens `Normalizer.optimizeNesting` to alphabetize nesting order, even if the current node is not an only child. This is necessary because browsers (at least Chrome) will natively swap the nesting order of tags when typing in certain locations (such as the end of a link), before Quill has an opportunity to intervene.

With this addition, the DOM should be fully deterministic. No matter the sequence of editing operations, the same rich-text is always rendered to the same canonical html, in which no inline tag may be a parent to another inline tag of an "earlier" name, alphabetically. For example:

```
<i>Hello <b>World</b>!</i>   =>   <i>Hello </i><b><i>World</i></b><i>!</i>
```

While that may lead to more complex markup in some cases, we ensure that `<a>` is always outermost, and that consecutive linked characters create a single `<a>` tag, even if the contents are a mix of other inline formats.

---

There are several unrelated changes here that were necessary to make the quill dev environment functional again. i.e. `$ grunt dev` and http://localhost:9000/examples/index