### PR TITLE
Add dom.splitAfter to fix a bug in dom.isolate

### DIFF
--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -90,7 +90,7 @@ class Wrapper
     return @node?.nodeType == dom.TEXT_NODE
 
   isolate: (root) ->
-    dom(@node.nextSibling).splitBefore(root) if @node.nextSibling?
+    this.splitAfter(root)
     this.splitBefore(root)
     return this
 
@@ -180,9 +180,14 @@ class Wrapper
     @node = newNode
     return this
 
-  splitBefore: (root, force = false) ->
+  splitAfter: (root) ->
     return this if @node == root or @node.parentNode == root
-    if @node.previousSibling? or force
+    dom(@node.nextSibling).splitBefore(root) if @node.nextSibling?
+    return dom(@node.parentNode).splitAfter(root)
+
+  splitBefore: (root) ->
+    return this if @node == root or @node.parentNode == root
+    if @node.previousSibling?
       parentNode = @node.parentNode
       parentClone = parentNode.cloneNode(false)
       parentNode.parentNode.insertBefore(parentClone, parentNode.nextSibling)

--- a/test/unit/lib/dom.coffee
+++ b/test/unit/lib/dom.coffee
@@ -482,13 +482,79 @@ describe('DOM', ->
         '.replace(/\s+/g, ''))
         expect(retNode).toEqual(@container.lastChild)
       )
+    )
 
-      it('split force', ->
-        node = @container.querySelector('span')
-        retNode = dom(node).splitBefore(@container, true).get()
+    describe('splitAfter()', ->
+      beforeEach( ->
+        @container.innerHTML = '
+          <div>
+            <span>One</span>
+            <b>Two</b>
+            <div>
+              <i>Three</i>
+              <s>Four</s>
+              <u>Five</u>
+            </div>
+            <a>Six</a>
+          </div>
+        '.replace(/\s+/g, '')
+      )
+
+      it('single split', ->
+        node = @container.querySelector('b')
+        retNode = dom(node).splitAfter(@container).get()
         expect(@container).toEqualHTML('
           <div>
+            <span>One</span>
+            <b>Two</b>
           </div>
+          <div>
+            <div>
+              <i>Three</i>
+              <s>Four</s>
+              <u>Five</u>
+            </div>
+            <a>Six</a>
+          </div>
+        '.replace(/\s+/g, ''))
+        expect(retNode).toEqual(@container.firstChild)
+      )
+
+      it('split multiple', ->
+        node = @container.querySelector('s')
+        retNode = dom(node).splitAfter(@container).get()
+        expect(@container).toEqualHTML('
+          <div>
+            <span>One</span>
+            <b>Two</b>
+            <div>
+              <i>Three</i>
+              <s>Four</s>
+            </div>
+          </div>
+          <div>
+            <div>
+              <u>Five</u>
+            </div>
+            <a>Six</a>
+          </div>
+        '.replace(/\s+/g, ''))
+        expect(retNode).toEqual(@container.firstChild)
+      )
+
+      it('split none', ->
+        node = @container.querySelector('a')
+        html = @container.innerHTML
+        retNode = dom(node).splitAfter(@container).get()
+        expect(@container).toEqualHTML(html)
+        expect(retNode).toEqual(@container.lastChild)
+      )
+
+      it('split parent', ->
+        node = @container.querySelector('u')
+        html = @container.innerHTML
+        retNode = dom(node).splitAfter(@container).get()
+        expect(@container).toEqualHTML('
           <div>
             <span>One</span>
             <b>Two</b>
@@ -498,8 +564,11 @@ describe('DOM', ->
               <u>Five</u>
             </div>
           </div>
+          <div>
+            <a>Six</a>
+          </div>
         '.replace(/\s+/g, ''))
-        expect(retNode).toEqual(node.parentNode)
+        expect(retNode).toEqual(@container.firstChild)
       )
     )
 
@@ -580,18 +649,17 @@ describe('DOM', ->
     describe('isolate', ->
       tests =
         'before':
-          target: 'u'
+          target: 'b'
           html: '
             <div>
               <div>
                 <i>One</i>
                 <s>Two</s>
+                <u>Three</u>
               </div>
             </div>
             <div>
-              <div>
-                <u>Three</u>
-              </div>
+              <b>Four</b>
             </div>'
         'after':
           target: 'i'
@@ -606,6 +674,7 @@ describe('DOM', ->
                 <s>Two</s>
                 <u>Three</u>
               </div>
+              <b>Four</b>
             </div>'
         'both':
           target: 's'
@@ -624,7 +693,26 @@ describe('DOM', ->
               <div>
                 <u>Three</u>
               </div>
+              <b>Four</b>
             </div>'
+        'after parent':
+          target: 'u'
+          html: '
+            <div>
+              <div>
+                <i>One</i>
+                <s>Two</s>
+              </div>
+            </div>
+            <div>
+              <div>
+                <u>Three</u>
+              </div>
+            </div>
+            <div>
+              <b>Four</b>
+            </div>
+          '
 
       _.each(tests, (test, name) ->
         it(name, ->
@@ -635,6 +723,7 @@ describe('DOM', ->
                 <s>Two</s>
                 <u>Three</u>
               </div>
+              <b>Four</b>
             </div>
           '.replace(/\s+/g, '')
           node = @container.querySelector(test.target)


### PR DESCRIPTION
I introduced a bug in #22, where after certain sequences of formatting operations, unexpected ranges of text would be affected. e.g. Selecting the first word in a paragraph, then toggling on `bold` then `italic` would result in the entire paragraph being italicized.

I traced this to over-zealous behavior of `Normalizer.optimizeNesting` which was not fully isolating the node to operate on. So, I looked at `dom(node).isolate()`, and found a bug where the node's parents could still have `nextSiblings`. I fixed this with a more robust implementation of `dom(node).splitAfter(root)` which ensures that the node and all of its parents are the lastChild in their container, similar to how splitBefore ensures the node and all of its parents are the firstChild in their container. Example:

```
<div>
  <span>
    <s>One</s>
    <u>Two</u>
  </span>
  <i>Three</u>
</div>

dom(u).isolate(div)

// before
<div>
  <span>
    <s>One</s>
  </span>
</div>
<div>
  <span>
    <u>Two</u>
  </span>
  <i>Three</u>
</div>

// after
<div>
  <span>
    <s>One</s>
  </span>
</div>
<div>
  <span>
    <u>Two</u>
  </span>
</div>
<div>
  <i>Three</u>
</div>
```

I added several new tests to verify this works as intended. Now, `optimizeNesting` can safely reorder tags, and the normalizer does not inadvertently change the semantics of the markup it produces.