### PR TITLE
Fix optimize nesting

### DIFF
--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -91,8 +91,7 @@ class Wrapper
 
   isolate: (root) ->
     this.splitAfter(root)
-    this.splitBefore(root)
-    return this
+    return this.splitBefore(root)
 
   length: ->
     return 0 unless @node?

--- a/test/unit/lib/dom.coffee
+++ b/test/unit/lib/dom.coffee
@@ -650,6 +650,7 @@ describe('DOM', ->
       tests =
         'before':
           target: 'b'
+          result: 'div:nth-child(2)'
           html: '
             <div>
               <div>
@@ -663,6 +664,7 @@ describe('DOM', ->
             </div>'
         'after':
           target: 'i'
+          result: 'div'
           html: '
             <div>
               <div>
@@ -678,6 +680,7 @@ describe('DOM', ->
             </div>'
         'both':
           target: 's'
+          result: 'div:nth-child(2)'
           html: '
             <div>
               <div>
@@ -697,6 +700,7 @@ describe('DOM', ->
             </div>'
         'after parent':
           target: 'u'
+          result: 'div:nth-child(2)'
           html: '
             <div>
               <div>
@@ -729,7 +733,7 @@ describe('DOM', ->
           node = @container.querySelector(test.target)
           retNode = dom(node).isolate(@container).get()
           expect(@container).toEqualHTML(test.html.replace(/\s+/g, ''))
-          expect(retNode).toEqual(node)
+          expect(retNode).toEqual(@container.querySelector(test.result))
         )
       )
     )


### PR DESCRIPTION
Apparently, `Normalizer.optimizeNesting` is still behaving badly. This adds a bunch more tests and refactors the method entirely, in order to catch more cases of un-isolated modifications and to merge similar tags more aggressively. I've never been more confident that `optimizeNesting` and `optimizeLine` are acting as expected.