### PR TITLE
I18n keyboard binding

### DIFF
--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -380,17 +380,6 @@ dom = _.extend(dom,
     '32px': 6
     '48px': 7
 
-  KEYS:
-    BACKSPACE : 8
-    TAB       : 9
-    ENTER     : 13
-    ESCAPE    : 27
-    LEFT      : 37
-    UP        : 38
-    RIGHT     : 39
-    DOWN      : 40
-    DELETE    : 46
-
   BLOCK_TAGS: {
     'ADDRESS'
     'ARTICLE'

--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -292,12 +292,6 @@ class Wrapper
     else
       event = document.createEvent('KeyboardEvent')
       lastKeyEvent = _.clone(options)
-      if _.isNumber(options.key)
-        lastKeyEvent.which = options.key
-      else if _.isString(options.key)
-        lastKeyEvent.which = options.key.toUpperCase().charCodeAt(0)
-      else
-        lastKeyEvent.which = 0
       # FF uses initKeyEvent, Webkit uses initKeyboardEvent
       initFn = if _.isFunction(event.initKeyboardEvent) then 'initKeyboardEvent' else 'initKeyEvent'
       event[initFn](eventName, options.bubbles, options.cancelable, window, options.ctrlKey, options.altKey, options.shiftKey, options.metaKey, 0, 0)

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -7,6 +7,7 @@ Delta  = Quill.require('delta')
 class Keyboard
   @hotkeys:
     BOLD:       { key: 'b',          metaKey: true }
+    DELETE:     ['Backspace', 'Delete']
     INDENT:     { key: 'Tab' }
     ITALIC:     { key: 'i',          metaKey: true }
     OUTDENT:    { key: 'Tab',        shiftKey: true }
@@ -107,7 +108,7 @@ class Keyboard
     )
 
   _initDeletes: ->
-    this.addHotkey(['Backspace', 'Delete'], (range, hotkey) =>
+    this.addHotkey(Keyboard.hotkeys.DELETE, (range, hotkey) =>
       if range? and @quill.getLength() > 0
         { start, end } = range
         if start != end
@@ -133,11 +134,11 @@ class Keyboard
     )
 
   _initHotkeys: ->
-    this.addHotkey('Tab', (range) =>
+    this.addHotkey(Keyboard.hotkeys.INDENT, (range) =>
       this._onTab(range, false)
       return false
     )
-    this.addHotkey({ key: 'Tab', shiftKey: true }, (range) =>
+    this.addHotkey(Keyboard.hotkeys.OUTDENT, (range) =>
       # TODO implement when we implement multiline tabs
       return false
     )

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -6,11 +6,11 @@ Delta  = Quill.require('delta')
 
 class Keyboard
   @hotkeys:
-    BOLD:       { key: 'B',          metaKey: true }
-    INDENT:     { key: dom.KEYS.TAB }
-    ITALIC:     { key: 'I',          metaKey: true }
-    OUTDENT:    { key: dom.KEYS.TAB, shiftKey: true }
-    UNDERLINE:  { key: 'U',          metaKey: true }
+    BOLD:       { key: 'b',          metaKey: true }
+    INDENT:     { key: 'Tab' }
+    ITALIC:     { key: 'i',          metaKey: true }
+    OUTDENT:    { key: 'Tab',        shiftKey: true }
+    UNDERLINE:  { key: 'u',          metaKey: true }
 
   constructor: (@quill, options) ->
     @hotkeys = {}
@@ -25,22 +25,19 @@ class Keyboard
     _.each(hotkeys, (hotkey) =>
       hotkey = if _.isObject(hotkey) then _.clone(hotkey) else { key: hotkey }
       hotkey.callback = callback
-      which = if _.isNumber(hotkey.key) then hotkey.key else hotkey.key.toUpperCase().charCodeAt(0)
-      @hotkeys[which] ?= []
-      @hotkeys[which].push(hotkey)
+      @hotkeys[hotkey.key] ?= []
+      @hotkeys[hotkey.key].push(hotkey)
     )
 
   removeHotkeys: (hotkey, callback) ->
-    hotkey = if _.isString(hotkey) then hotkey.toUpperCase() else hotkey
     hotkey = if Keyboard.hotkeys[hotkey] then Keyboard.hotkeys[hotkey] else hotkey
-    hotkey = if _.isObject(hotkey) then hotkey else { key: hotkey }
-    which = if _.isNumber(hotkey.key) then hotkey.key else hotkey.key.charCodeAt(0)
-    @hotkeys[which] ?= []
-    [removed, kept] = _.partition(@hotkeys[which], (handler) ->
+    key = if _.isObject(hotkey) then hotkey.key else hotkey
+    @hotkeys[key] ?= []
+    [removed, kept] = _.partition(@hotkeys[key], (handler) ->
       _.isEqual(hotkey, _.omit(handler, 'callback')) and
         (!callback or callback == handler.callback)
     )
-    @hotkeys[which] = kept
+    @hotkeys[key] = kept
     return _.map(removed, 'callback')
 
   toggleFormat: (range, format) ->
@@ -60,8 +57,8 @@ class Keyboard
 
   _initEnter: ->
     keys = [
-      { key: dom.KEYS.ENTER }
-      { key: dom.KEYS.ENTER, shiftKey: true }
+      { key: 'Enter' }
+      { key: 'Enter', shiftKey: true }
     ]
     this.addHotkey(keys, (range, hotkey, event) =>
       return true unless range?
@@ -110,7 +107,7 @@ class Keyboard
     )
 
   _initDeletes: ->
-    this.addHotkey([dom.KEYS.DELETE, dom.KEYS.BACKSPACE], (range, hotkey) =>
+    this.addHotkey(['Backspace', 'Delete'], (range, hotkey) =>
       if range? and @quill.getLength() > 0
         { start, end } = range
         if start != end
@@ -122,7 +119,7 @@ class Keyboard
             start = start - 1
           @quill.deleteText(start, end, Quill.sources.USER)
         else
-          if hotkey.key == dom.KEYS.BACKSPACE
+          if hotkey.key == 'Backspace'
             [line, offset] = @quill.editor.doc.findLineAt(start)
             if offset == 0 and (line.formats.bullet or line.formats.list)
               format = if line.formats.bullet then 'bullet' else 'list'
@@ -136,11 +133,11 @@ class Keyboard
     )
 
   _initHotkeys: ->
-    this.addHotkey(Keyboard.hotkeys.INDENT, (range) =>
+    this.addHotkey('Tab', (range) =>
       this._onTab(range, false)
       return false
     )
-    this.addHotkey(Keyboard.hotkeys.OUTDENT, (range) =>
+    this.addHotkey({ key: 'Tab', shiftKey: true }, (range) =>
       # TODO implement when we implement multiline tabs
       return false
     )
@@ -157,7 +154,7 @@ class Keyboard
   _initListeners: ->
     dom(@quill.root).on('keydown', (event) =>
       prevent = false
-      _.each(@hotkeys[event.which], (hotkey) =>
+      _.each(@hotkeys[event.key], (hotkey) =>
         metaKey = if dom.isMac() then event.metaKey else event.metaKey or event.ctrlKey
         return if !!hotkey.metaKey != !!metaKey
         return if !!hotkey.shiftKey != !!event.shiftKey

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -32,13 +32,13 @@ class Keyboard
 
   removeHotkeys: (hotkey, callback) ->
     hotkey = if Keyboard.hotkeys[hotkey] then Keyboard.hotkeys[hotkey] else hotkey
-    key = if _.isObject(hotkey) then hotkey.key else hotkey
-    @hotkeys[key] ?= []
-    [removed, kept] = _.partition(@hotkeys[key], (handler) ->
+    hotkey = if _.isObject(hotkey) then hotkey else { key: hotkey }
+    @hotkeys[hotkey.key] ?= []
+    [removed, kept] = _.partition(@hotkeys[hotkey.key], (handler) ->
       _.isEqual(hotkey, _.omit(handler, 'callback')) and
         (!callback or callback == handler.callback)
     )
-    @hotkeys[key] = kept
+    @hotkeys[hotkey.key] = kept
     return _.map(removed, 'callback')
 
   toggleFormat: (range, format) ->

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -110,6 +110,7 @@ class LinkTooltip extends Tooltip
   _onKeyboard: ->
     range = @quill.getSelection()
     this._toggle(range, !this._findAnchor(range))
+    return false
 
   _toggle: (range, value) ->
     return unless range

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -16,7 +16,7 @@ class LinkTooltip extends Tooltip
       <a href="javascript:;" class="done">Done</a>'
 
   @hotkeys:
-    LINK: { key: 'K', metaKey: true }
+    LINK: { key: 'k', metaKey: true }
 
   constructor: (@quill, options = {}) ->
     @options = _.defaults(options, LinkTooltip.DEFAULTS)

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -25,7 +25,7 @@ class Toolbar
     )
     @quill.on(Quill.events.TEXT_CHANGE, => this.updateActive())
     @quill.onModuleLoad('keyboard', (keyboard) =>
-      keyboard.addHotkey([dom.KEYS.BACKSPACE, dom.KEYS.DELETE], =>
+      keyboard.addHotkey(['Backspace', 'Delete'], =>
         _.defer(_.bind(this.updateActive, this))
       )
     )

--- a/src/modules/tooltip.coffee
+++ b/src/modules/tooltip.coffee
@@ -23,11 +23,11 @@ class Tooltip
 
   initTextbox: (textbox, enterCallback, escapeCallback) ->
     dom(textbox).on('keydown', (event) =>
-      switch event.which
-        when dom.KEYS.ENTER
+      switch event.key
+        when 'Enter'
           event.preventDefault()
           enterCallback.call(this)
-        when dom.KEYS.ESCAPE
+        when 'Escape'
           event.preventDefault()
           escapeCallback.call(this)
         else

--- a/src/modules/undo-manager.coffee
+++ b/src/modules/undo-manager.coffee
@@ -10,8 +10,8 @@ class UndoManager
     userOnly: false
 
   @hotkeys:
-    UNDO: { key: 'Z', metaKey: true }
-    REDO: { key: 'Z', metaKey: true, shiftKey: true }
+    UNDO: { key: 'z', metaKey: true }
+    REDO: { key: 'Z', metaKey: true }
 
   constructor: (@quill, options = {}) ->
     @options = _.defaults(options, UndoManager.DEFAULTS)
@@ -29,7 +29,7 @@ class UndoManager
       )
       redoKey = [UndoManager.hotkeys.REDO]
       if (navigator.platform.indexOf('Win') > -1)
-        redoKey.push({ key: 'Y', metaKey: true })
+        redoKey.push({ key: 'y', metaKey: true })
       keyboard.addHotkey(redoKey, =>
         @quill.editor.checkUpdate()
         this.redo()

--- a/src/modules/undo-manager.coffee
+++ b/src/modules/undo-manager.coffee
@@ -11,7 +11,12 @@ class UndoManager
 
   @hotkeys:
     UNDO: { key: 'z', metaKey: true }
-    REDO: { key: 'Z', metaKey: true }
+    REDO: [
+      # mozilla and firefox report event.key as 'z', while chrome reports as 'Z'
+      { key: 'y', metaKey: true },
+      { key: 'z', shiftKey: true, metaKey: true },
+      { key: 'Z', shiftKey: true, metaKey: true }
+    ]
 
   constructor: (@quill, options = {}) ->
     @options = _.defaults(options, UndoManager.DEFAULTS)
@@ -27,10 +32,7 @@ class UndoManager
         this.undo()
         return false
       )
-      redoKey = [UndoManager.hotkeys.REDO]
-      if (navigator.platform.indexOf('Win') > -1)
-        redoKey.push({ key: 'y', metaKey: true })
-      keyboard.addHotkey(redoKey, =>
+      keyboard.addHotkey(UndoManager.hotkeys.REDO, =>
         @quill.editor.checkUpdate()
         this.redo()
         return false

--- a/test/unit/modules/keyboard.coffee
+++ b/test/unit/modules/keyboard.coffee
@@ -36,7 +36,7 @@ describe('Keyboard', ->
       @container.innerHTML = '<div><div>01234</div></div>'
       @quill = new Quill(@container.firstChild)
       @keyboard = @quill.getModule('keyboard')
-      @enterKey = { key: dom.KEYS.ENTER }
+      @enterKey = { key: 'Enter' }
     )
 
     it('inserts a newline', ->
@@ -124,7 +124,7 @@ describe('Keyboard', ->
       @quill.formatText(0, @quill.getLength(), { 'bold': true, 'size': size })
 
       @quill.setSelection(@quill.getLength(), @quill.getLength())
-      dom(@quill.root).trigger('keydown', { key: dom.KEYS.ENTER })
+      dom(@quill.root).trigger('keydown', { key: 'Enter' })
 
       expect(dom($('.ql-bold').get(0)).hasClass('ql-active')).toBe(true)
       expect(dom($('.ql-size').get(0)).value()).toBe(size)
@@ -134,13 +134,13 @@ describe('Keyboard', ->
       counter = 0
       fn = -> counter += 1
       keyboard = @quill.getModule('keyboard')
-      keyboard.addHotkey('S', fn)
-      dom(@quill.root).trigger('keydown', { key: 'S' })
+      keyboard.addHotkey('s', fn)
+      dom(@quill.root).trigger('keydown', { key: 's' })
       expect(counter).toBe(1)
-      result = keyboard.removeHotkeys('S', fn)
+      result = keyboard.removeHotkeys('s', fn)
       expect(result.length).toBe(1)
       expect(result[0]).toBe(fn);
-      dom(@quill.root).trigger('keydown', { key: 'S' })
+      dom(@quill.root).trigger('keydown', { key: 's' })
       expect(counter).toBe(1)
     )
 


### PR DESCRIPTION
Switch the keyboard module to use `event.key` instead of `event.which` which is the modern way of doing things. This has the benefit of being able to bind to specific key character events in a reliable way across different keyboard layouts.