### PR TITLE
Bugfix: Link Removal

### DIFF
--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -41,7 +41,7 @@ class Leaf extends LinkedList.Node
         @node = textNode
     @length = @text.length
 
-  findAdjacentLeaves: (offset, formats) ->
+  findAdjacentLeaves: (offset, formats = {}) ->
     leaves = [this]
 
     # Collect previous leaves + update offset from click-point
@@ -67,7 +67,7 @@ class Leaf extends LinkedList.Node
 
   hasFormats: (formats) ->
     return Object.keys(formats).every((formatKey) ->
-      return formatKey in @formats && @formats[formatKey] == formats[formatKey]
+      return @formats[formatKey] == formats[formatKey]
     )
 
 

--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -66,6 +66,10 @@ class Leaf extends LinkedList.Node
     return [leaves, offset]
 
   hasFormats: (formats) ->
+    console.log(this)
+    console.log(formats)
+    console.log(@formats)
+
     return Object.keys(formats).every((formatKey) ->
       return @formats[formatKey] == formats[formatKey]
     )

--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -41,5 +41,34 @@ class Leaf extends LinkedList.Node
         @node = textNode
     @length = @text.length
 
+  findAdjacentLeaves: (offset, formats) ->
+    leaves = [this]
+
+    # Collect previous leaves + update offset from click-point
+    prev = @prev;
+    while prev?
+      if prev.hasFormats(formats)
+        offset += prev.length
+        leaves = [prev].concat(leaves)
+        prev = prev.prev
+      else
+        prev = null
+
+    # Collect next leaves
+    next = @next;
+    while next?
+      if next.hasFormats(formats)
+        leaves = leaves.concat([next])
+        next = next.next
+      else
+        next = null
+
+    return [leaves, offset]
+
+  hasFormats: (formats) ->
+    return Object.keys(formats).forEach((formatKey) ->
+      return formatKey in @formats && @formats[formatKey] === formats[formatKey]
+    )
+
 
 module.exports = Leaf

--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -41,34 +41,32 @@ class Leaf extends LinkedList.Node
         @node = textNode
     @length = @text.length
 
-  findAdjacentLeaves: (offset, formats = {}) ->
-    leaves = [this]
+  findMatchingSiblings: (formats = {}) ->
+    prevLeaves = []
+    nextLeaves = []
 
-    # Collect previous leaves + update offset from click-point
-    prev = @prev;
+    prev = @prev
     while prev?
       if prev.hasFormats(formats)
-        offset += prev.length
-        leaves = [prev].concat(leaves)
+        prevLeaves.push(prev)
         prev = prev.prev
       else
         prev = null
 
-    # Collect next leaves
-    next = @next;
+    next = @next
     while next?
       if next.hasFormats(formats)
-        leaves = leaves.concat([next])
+        nextLeaves.push(next)
         next = next.next
       else
         next = null
 
-    return [leaves, offset]
+    return [prevLeaves, nextLeaves]
 
   hasFormats: (formats) ->
     leafHasFormats = true
     for formatKey of formats
-      if not @formats.hasOwnProperty(formatKey) or @formats[formatKey] != formats[formatKey]
+      if @formats[formatKey] != formats[formatKey]
         leafHasFormats = false
 
     return leafHasFormats

--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -66,13 +66,12 @@ class Leaf extends LinkedList.Node
     return [leaves, offset]
 
   hasFormats: (formats) ->
-    console.log(this)
-    console.log(formats)
-    console.log(@formats)
+    leafHasFormats = true
+    for formatKey of formats
+      if not @formats.hasOwnProperty(formatKey) or @formats[formatKey] != formats[formatKey]
+        leafHasFormats = false
 
-    return Object.keys(formats).every((formatKey) ->
-      return @formats[formatKey] == formats[formatKey]
-    )
+    return leafHasFormats
 
 
 module.exports = Leaf

--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -66,8 +66,8 @@ class Leaf extends LinkedList.Node
     return [leaves, offset]
 
   hasFormats: (formats) ->
-    return Object.keys(formats).forEach((formatKey) ->
-      return formatKey in @formats && @formats[formatKey] === formats[formatKey]
+    return Object.keys(formats).every((formatKey) ->
+      return formatKey in @formats && @formats[formatKey] == formats[formatKey]
     )
 
 

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -99,7 +99,7 @@ class LinkTooltip extends Tooltip
     return null
 
   _expandRange: (range) ->
-    [leaf, offset] = @quill.editor.doc.findLeavesAt(range.start, true)
+    [leaf, offset] = @quill.editor.doc.findLeafAt(range.start, true)
 
     # Get all adjacent leaves from clicked leaf that share the same link format
     leaves = [leaf]

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -100,16 +100,13 @@ class LinkTooltip extends Tooltip
 
   _expandRange: (range) ->
     [leaf, offset] = @quill.editor.doc.findLeafAt(range.start, true)
-
-    # Get all adjacent leaves from clicked leaf that share the same link format
-    leaves = [leaf]
-    if leaf?
-      [leaves, offset] = leaf.findAdjacentLeaves(offset, { link: leaf.formats.link })
-
-    # Update range bounds to include all leaves
     start = range.start - offset
-    end = start
-    leaves.forEach((leaf) -> end += leaf.length)
+    end = start + leaf.length
+
+    # Update range bounds to include siblings
+    [prev, next] = leaf.findMatchingSiblings({ link: leaf.formats.link })
+    prev.forEach((leaf) -> start -= leaf.length)
+    next.forEach((leaf) -> end += leaf.length)
 
     return { start, end }
 

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -99,9 +99,18 @@ class LinkTooltip extends Tooltip
     return null
 
   _expandRange: (range) ->
-    [leaf, offset] = @quill.editor.doc.findLeafAt(range.start, true)
+    [leaf, offset] = @quill.editor.doc.findLeavesAt(range.start, true)
+
+    # Get all adjacent leaves from clicked leaf that share the same link format
+    leaves = [leaf]
+    if leaf?
+      [leaves, offset] = leaf.findAdjacentLeaves(offset, { link: leaf.formats.link })
+
+    # Update range bounds to include all leaves
     start = range.start - offset
-    end = start + leaf.length
+    end = start
+    leaves.forEach((leaf) -> end += leaf.length)
+
     return { start, end }
 
   _onToolbar: (range, value) ->


### PR DESCRIPTION
Fixes https://github.com/voxmedia/anthem/issues/5042

We allow users to apply multiple non-line formats to linked text. So, it's possible each word in a multi-word link can have different non-line formats. Because of the nature of `rich-text`, this means the link attribute will be spread out across multiple ops in a Delta like so

```js
[
  ...,
  { insert: "Multi-word ", attributes: { link: "something.com" } },
  { insert: "link", attributes: { link: "something.com", italic: true } }
]
```

Within Quill itself, these Delta ops are turned into DOM `Leaf` nodes. This reality has lead to a bug when removing a link. Quill will only expand the link removal range to include the current Leaf/op of the user-click point. In reality, we want all Leafs/ops for the link to be included in the removal range.

This PR makes that possible with a new function added to the Quill Leaf class `Leaf#findAdjacentLeaves`. This function will collect a list of Leafs adjacent on both sides to the supplied Leaf that share a set of same attributes. We then use this within the LinkTooltip to ensure we expand our removal range to cover all Leafs for the link, both the Leaf clicked and those adjacent.