### PR TITLE
Leaf.prototype.findMatchingSiblings fix

### DIFF
--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -66,7 +66,7 @@ class Leaf extends LinkedList.Node
   hasFormats: (formats) ->
     leafHasFormats = true
     for formatKey of formats
-      if @formats[formatKey] != formats[formatKey]
+      if !_.isEqual(@formats[formatKey], formats[formatKey])
         leafHasFormats = false
 
     return leafHasFormats


### PR DESCRIPTION
When finding matching siblings for a Leaf, the formats blob used may include formats of nested objects. In that case, we need to perform a deep equality check. Let's always do this via Lodash.